### PR TITLE
Updaing junit formatting

### DIFF
--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -10,17 +10,17 @@ public struct JUnitReporter: Reporter {
     }
 
     public static func generateReport(_ violations: [StyleViolation]) -> String {
-        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>\n" +
             violations.map({ violation -> String in
                 let fileName = (violation.location.file ?? "<nopath>").escapedForXML()
                 let severity = violation.severity.rawValue + ":\n"
                 let message = severity + "Line:" + String(violation.location.line ?? 0) + " "
                 let reason = violation.reason.escapedForXML()
                 return [
-                    "\n\t<testcase classname='Formatting Test' name='\(fileName)\'>\n",
-                    "<failure message='\(reason)\'>" + message + "</failure>",
-                    "\t</testcase>"
+                    "\t<testcase classname='Swift Lint' name='\(fileName)\'>\n",
+                    "\t\t<failure message='\(reason)\'>" + message + "</failure>\n",
+                    "\t</testcase>\n"
                 ].joined()
-            }).joined() + "\n</testsuite></testsuites>"
+            }).joined() + "</testsuite></testsuites>"
     }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedJunitReporterOutput.xml
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedJunitReporterOutput.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites><testsuite>
-	<testcase classname='Formatting Test' name='filename'>
-<failure message='Violation Reason.'>warning:
-Line:1 </failure>	</testcase>
-	<testcase classname='Formatting Test' name='filename'>
-<failure message='Violation Reason.'>error:
-Line:1 </failure>	</testcase>
-	<testcase classname='Formatting Test' name='filename'>
-<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;.'>error:
-Line:1 </failure>	</testcase>
-	<testcase classname='Formatting Test' name='&lt;nopath&gt;'>
-<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals.'>error:
-Line:0 </failure>	</testcase>
+	<testcase classname='Swift Lint' name='filename'>
+		<failure message='Violation Reason.'>warning:
+Line:1 </failure>
+	</testcase>
+	<testcase classname='Swift Lint' name='filename'>
+		<failure message='Violation Reason.'>error:
+Line:1 </failure>
+	</testcase>
+	<testcase classname='Swift Lint' name='filename'>
+		<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;.'>error:
+Line:1 </failure>
+	</testcase>
+	<testcase classname='Swift Lint' name='&lt;nopath&gt;'>
+		<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals.'>error:
+Line:0 </failure>
+	</testcase>
 </testsuite></testsuites>


### PR DESCRIPTION
Updaing junit formatting to be more consistent and changing classname of failure to Swift Lint